### PR TITLE
Use full class name for code block language

### DIFF
--- a/src/Statiq.Docs/Pipelines/Api.cs
+++ b/src/Statiq.Docs/Pipelines/Api.cs
@@ -39,7 +39,7 @@ namespace Statiq.Docs.Pipelines
                             new AnalyzeCSharp()
                                 .WhereNamespaces(ctx.Settings.GetBool(DocsKeys.IncludeGlobalNamespace))
                                 .WherePublic()
-                                .WithCssClasses("code", "cs")
+                                .WithCssClasses("code", "language-csharp")
                                 .WithDestinationPrefix(ctx.GetPath(DocsKeys.ApiPath))
                                 .WithAssemblies(Config.FromContext<IEnumerable<string>>(ctx => ctx.GetList<string>(DocsKeys.AssemblyFiles)))
                                 .WithProjects(Config.FromContext<IEnumerable<string>>(ctx => ctx.GetList<string>(DocsKeys.ProjectFiles)))


### PR DESCRIPTION
This fixes an incompatibility between `Statiq.Highlight` and `Statiq.Docs` as `Statiq.Highlight` is specifically looking for `language` to determine what language to render as. It might still auto-detect the language correctly without it however given we _know_ what language it is, we should be using it.

https://github.com/statiqdev/Statiq.Framework/blob/1a8bd58e6f1a4e63f0cae2870db78126bc511928/src/extensions/Statiq.Highlight/HighlightCode.cs#L121