### PR TITLE
Xrefs for API symbols should not contain whitespace

### DIFF
--- a/src/Statiq.Docs/Pipelines/Api.cs
+++ b/src/Statiq.Docs/Pipelines/Api.cs
@@ -76,7 +76,7 @@ namespace Statiq.Docs.Pipelines
                             // Also convert angle brackets to dashes so they don't risk getting escaped
                             metadataItems.Add(
                                 WebKeys.Xref, "api-"
-                                + doc.GetString(CodeAnalysisKeys.QualifiedName).Replace("<", "-").Replace(">", "-"));
+                                + doc.GetString(CodeAnalysisKeys.QualifiedName).Replace("<", "-").Replace(">", "-").Replace(" ", string.Empty));
 
                             // Add the layout path if one was defined
                             NormalizedPath apiLayout = ctx.GetPath(DocsKeys.ApiLayout);


### PR DESCRIPTION
This fixes whitespace in API symbols by replacing it with empty string 

Issue refs:  
#55 
#60 
 
discussion ref:
 https://github.com/statiqdev/Discussions/discussions/210#discussioncomment-7974581

Thanks,
Rohit Mahajan